### PR TITLE
Unified memory model works in int_test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=nvcc
-CFLAGS=-lm -lcudadevrt -rdc=true
+CFLAGS=-lm -lcudadevrt -rdc=true -g -arch=sm_60
 INIT := init
 TESTS := cont_pdf_test cont_gof_test int_test 
 MODULES := distrs utils gmm gmm_gibbs main


### PR DESCRIPTION
Note that to make the CUDA kernel work correctly, we need to
compile with arch >= sm_60 due to atomic fp64 requirements
in the current implementation.